### PR TITLE
avoid sympy bug in ast_parser

### DIFF
--- a/src/driven/data_sets/expression_profile.py
+++ b/src/driven/data_sets/expression_profile.py
@@ -30,6 +30,12 @@ from driven.utils import get_common_start
 
 
 class Transform(NodeTransformer):
+    """
+    Transform a python ast syntax tree to a sympy one.
+
+    The output of `cobra.core.gene.parse_gpr` is an extremely limited 
+    syntax tree so we don't need to do much.
+    """
 
     def visit_Name(self, node):
         return Symbol(node.id)
@@ -41,8 +47,21 @@ class Transform(NodeTransformer):
             return Add(*values)
         return node
 
-def parse_expr(s):
-    a, genes = parse_gpr(s.strip())
+def parse_expr(gene_reaction_rule):
+    """
+    Takes a gene_reaction_rule and converts it to a sympy expression.
+
+    Parameters
+    ----------
+        gene_reaction_rule: string
+            model reaction rule
+
+    Returns
+    -------
+        Tuple[sympy.Expr, Set[str]]: 
+            sympy expression, set of gene identifiers found
+    """
+    a, genes = parse_gpr(gene_reaction_rule.strip())
     a = Transform().visit(a)
     return a.body, genes
 

--- a/src/driven/data_sets/expression_profile.py
+++ b/src/driven/data_sets/expression_profile.py
@@ -44,7 +44,7 @@ class Transform(NodeTransformer):
 def parse_expr(s):
     a, genes = parse_gpr(s.strip())
     a = Transform().visit(a)
-    return a.body
+    return a.body, genes
 
 
 class ExpressionProfile(object):
@@ -348,7 +348,10 @@ class ExpressionProfile(object):
 
         """
         rule = reaction.gene_reaction_rule
-        expression = parse_expr(rule)
+        expression, genes = parse_expr(rule)
+        missing = genes - set(gene_values)
+        if missing:
+            raise ValueError("missing values for genes {}".format(missing))
         if by == "or2max_and2min":
             expression = expression.replace(Mul, Min).replace(Add, Max)
         elif by == "or2sum_and2min":

--- a/src/driven/data_sets/expression_profile.py
+++ b/src/driven/data_sets/expression_profile.py
@@ -353,7 +353,7 @@ class ExpressionProfile(object):
             expression = expression.replace(Mul, Min).replace(Add, Max)
         elif by == "or2sum_and2min":
             expression = expression.replace(Mul, Min)
-        return expression.subs(gene_values).evalf()
+        return float(expression.subs(gene_values).evalf())
 
     def to_dict(self, condition):
         """


### PR DESCRIPTION
Currently sympy has a bug that means that its `ast_parser` won't work on
pythons >= 3.5.

Also the parser *will not work* with gene IDs that have splice variants (i.e. they have a '.').

Solution: use cobra's own parse_gpr and then transform to a sympy expression using a NodeTransformer.
 